### PR TITLE
make use of pkg-config in configure.in

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -76,19 +76,16 @@ AC_HEADER_STDC
 # check for libtool
 AC_PROG_LIBTOOL
 
-AC_LANG_CPLUSPLUS
-# check libxml2
-AC_CHECK_LIB(xml2,xmlParseChunk, ,
-             AC_MSG_ERROR(Cannot find xml2 library!))
+m4_ifndef([PKG_PROG_PKG_CONFIG], [m4_fatal([Please install pkg-config.])])
+PKG_PROG_PKG_CONFIG
 
-#AC_HAVE_LIBRARY(xml2,[],[echo "Error libxml not found" ;exit -1])
+# pkg-config resolvable dependencies for consistent .pc file wit configure
+# script;
+# add new pkg-config dependencies here
+PC_DEPS="libxml-2.0"
+AC_SUBST([PC_DEPS])
 
-XML2_CFLAGS=`xml2-config --cflags`
-XML2_LIBS=`xml2-config --libs`
-
-AC_SUBST(XML2_CFLAGS)
-AC_SUBST(XML2_LIBS)
-
+PKG_CHECK_MODULES([DEPS], [$PC_DEPS])
 
 dnl ------------------------------------------------------------------------
 # system dependant part

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libfastrpc
 Section: Seznam
 Priority: optional
 Maintainer: Lukas Lobotka <lukas.lobotka@firma.seznam.cz>
-Build-Depends: debhelper (>=8), libxml2-dev, autoconf, libtool, automake, dh-autoreconf
+Build-Depends: debhelper (>=8), libxml2-dev, autoconf, libtool, automake, dh-autoreconf, pkg-config
 Standards-Version: 3.9.1
 
 Package: libfastrpc5

--- a/libfastrpc.pc.in
+++ b/libfastrpc.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: fastrpc
 Description: The seznam fastrpc library
 Version: @PACKAGE_VERSION@
-Requires:
+Requires: @PC_DEPS@
 URL: [not yet]
 Libs: -L${libdir} -lfastrpc
 Libs.private:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,7 +36,7 @@
 
 
 # warn on all
-AM_CXXFLAGS = -Wall -g -fPIC $(XML2_CFLAGS) ${CXXEXTRAFLAGS}
+AM_CXXFLAGS = -Wall -g -fPIC $(DEPS_CFLAGS) ${CXXEXTRAFLAGS}
 
 # extra compiler options
 AM_CPPFLAGS = -D_ISOC99_SOURCE -D__ENABLE_WSTRING=1
@@ -77,7 +77,7 @@ libfastrpc_la_SOURCES = frpcvalue.cc frpcarray.cc frpcstruct.cc frpcbinary.cc fr
                         frpcb64writer.cc frpcconfig.cc
 
 # with these flags (version info etc.)
-libfastrpc_la_LDFLAGS = @VERSION_INFO@ $(XML2_LIBS)
+libfastrpc_la_LDFLAGS = @VERSION_INFO@ $(DEPS_LIBS)
 
 
 # test program


### PR DESCRIPTION
- libxml2 has pkg-config, so let's use it
- pass pkg-config dependencies to our libfastrpc.pc.in file
