### PR TITLE
Accept unicode strings as dictionary keys in request.

### DIFF
--- a/python/pythonfeeder.cc
+++ b/python/pythonfeeder.cc
@@ -225,9 +225,9 @@ void Feeder_t::feedValue(PyObject *value)
         marshaller->packStruct(argc);
 
         while (PyDict_Next(value, &pos, &key, &member)) {
-            if(!PyString_Check(key)) {
+            if(!PyString_Check(key) && !PyUnicode_Check(key)) {
                 PyErr_SetString(PyExc_TypeError,
-                                "Key in Dictionary must be string.");
+                                "Key in Dictionary must be either string or unicode.");
                 throw PyError_t();
             }
 


### PR DESCRIPTION
Python 2 supports unicode keys in dictionaries. When passing a dictionary with unicode keys (e.g. previously created by json.loads) to FastRPC, the library throws an exception (and not very helpful one, to be honest).

This simple patch enables use of such dictionary keys.