### PR TITLE
Implemented X-Forwarded-For header for proxy ip origin info tunelling

### DIFF
--- a/src/frpchttp.h
+++ b/src/frpchttp.h
@@ -118,6 +118,7 @@ namespace FRPC {
     const std::string HTTP_HEADER_CACHE_CONTROL("Cache-Control");
     const std::string HTTP_HEADER_CACHE_PRAGMA("Pragma");
     const std::string HTTP_HEADER_ALLOW("Allow");
+    const std::string HTTP_HEADER_X_FORWARDED_FOR("X-Forwarded-For");
     const std::string HTTP_ACCEPT_RANGES("Accept-Ranges");
     
     class FRPC_DLLEXPORT HTTPHeader_t {

--- a/src/frpchttpclient.h
+++ b/src/frpchttpclient.h
@@ -149,6 +149,10 @@ public:
     */
     void readResponse(DataBuilder_t &builder);
 
+    /** used on proxy servers to set the x-forwarded-for header used for 
+     *  request origin tracking */
+    void setForwardHeader(const std::string &fwd) { forward = fwd; }
+
 private:
     void sendRequest(bool last = false );
     HTTPClient_t();
@@ -170,6 +174,7 @@ private:
     UnMarshaller_t *unmarshaller;
     bool useHTTP10;
     ProtocolVersion_t protocolVersion;
+    std::string forward;
 };
 
 } // namespace FRPC

--- a/src/frpcserverproxy.cc
+++ b/src/frpcserverproxy.cc
@@ -140,6 +140,10 @@ public:
         connector->setTimeout(timeout);
     }
 
+    void setForwardHeader(const std::string &fwd) {
+        forwarded = fwd;
+    }
+
     const URL_t& getURL() {
         return url;
     }
@@ -168,6 +172,7 @@ private:
     unsigned int serverSupportedProtocols;
     ProtocolVersion_t protocolVersion;
     std::auto_ptr<Connector_t> connector;
+    std::string forwarded;
 };
 
 Marshaller_t* ServerProxyImpl_t::createMarshaller(HTTPClient_t &client) {
@@ -248,6 +253,10 @@ Value_t& ServerProxyImpl_t::call(Pool_t &pool, const std::string &methodName,
                                  const Array_t &params)
 {
     HTTPClient_t client(io, url, connector.get(), useHTTP10);
+
+    if (!forwarded.empty())
+        client.setForwardHeader(forwarded);
+
     TreeBuilder_t builder(pool);
     std::auto_ptr<Marshaller_t>marshaller(createMarshaller(client));
     TreeFeeder_t feeder(*marshaller);
@@ -280,6 +289,10 @@ void ServerProxyImpl_t::call(DataBuilder_t &builder, const std::string &methodNa
                                  const Array_t &params)
 {
     HTTPClient_t client(io, url, connector.get(), useHTTP10);
+
+    if (!forwarded.empty())
+        client.setForwardHeader(forwarded);
+
     std::auto_ptr<Marshaller_t>marshaller(createMarshaller(client));
     TreeFeeder_t feeder(*marshaller);
 
@@ -311,6 +324,10 @@ Value_t& ServerProxyImpl_t::call(Pool_t &pool, const char *methodName,
                                  va_list args)
 {
     HTTPClient_t client(io, url, connector.get(), useHTTP10);
+
+    if (!forwarded.empty())
+        client.setForwardHeader(forwarded);
+
     TreeBuilder_t builder(pool);
     std::auto_ptr<Marshaller_t>marshaller(createMarshaller(client));
     TreeFeeder_t feeder(*marshaller);
@@ -372,6 +389,10 @@ void ServerProxy_t::setWriteTimeout(int timeout) {
 
 void ServerProxy_t::setConnectTimeout(int timeout) {
     sp->setConnectTimeout(timeout);
+}
+
+void ServerProxy_t::setForwardHeader(const std::string &fwd) {
+    sp->setForwardHeader(fwd);
 }
 
 const URL_t& ServerProxy_t::getURL() {

--- a/src/frpcserverproxy.h
+++ b/src/frpcserverproxy.h
@@ -541,6 +541,9 @@ public:
     /** @brief set new connect timeout */
     void setConnectTimeout(int timeout);
 
+    /** @brief sets a value to the X-Forwarded-For header, used on proxy servers. */
+    void setForwardHeader(const std::string &forwarded);
+
     const URL_t& getURL();
 
 private:


### PR DESCRIPTION
Hi,

we need original client ip tunelled through the server proxy code so that the backend server is able to see the original request address in case of frpc proxying.