### PR TITLE
Fixed build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,8 @@
 #                   Created.
 #
 
+AUTOMAKE_OPTIONS = foreign
+
 SUBDIRS = src
 
 EXTRA_DIST = debian/libfastrpc.control debian/libfastrpc-dev.control \


### PR DESCRIPTION
automake requires file README by default