### PR TITLE
erase method for FRPC::Struct_t

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfastrpc (6.1.0) UNRELEASED; urgency=low
+
+  * new method erase of FRPC::Struct_t class
+
+ -- Ondrej Tuma <ondrej.tuma@firma.seznam.cz>  Wed, 30 Aug 2017 11:03:04 +0200
+
 libfastrpc (6.0.5) testing; urgency=low
 
   * timout exception includes server url

--- a/src/value/frpcstruct.cc
+++ b/src/value/frpcstruct.cc
@@ -199,4 +199,8 @@ void Struct_t::clear() {
 
 }
 
+Struct_t::size_type Struct_t::erase(const Struct_t::key_type &key) {
+    return structData.erase(key);
+}
+
 }

--- a/src/value/frpcstruct.h
+++ b/src/value/frpcstruct.h
@@ -230,6 +230,13 @@ public:
          return structData.find(key);
     }
 
+    /**
+        @brief Remove Value_t from Struct_t with key
+        @param key is reference to Struct_t::key_type
+        @return Struct_t& reference with apended value
+    */
+    size_type erase(const key_type &key);
+
     /// static member
     static const Struct_t &FRPC_EMPTY;
 


### PR DESCRIPTION
we still need fastrpc6 on debian wheezy