### PR TITLE
fix: fixed problem with dump sensitive data with treeDump #GDPR_RS-108

### DIFF
--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+python-fastrpc (7.0.7) testing; urgency=medium
+
+  * fix: fixed problem with dump sensitive data with treeDump #GDPR_RS-108
+
+ -- Martin Junk <martin.junk@firma.seznam.cz>  Thu, 29 Mar 2018 15:54:13 +0200
+
 python-fastrpc (7.0.6) testing; urgency=low
 
   * Fix: Python2 version of the server object didn't convert the method signature, leaving it as a string. This broken some interactive clients

--- a/python/fastrpcmodule.cc
+++ b/python/fastrpcmodule.cc
@@ -2492,13 +2492,16 @@ int printPyFastRPCTree(PyObject *tree, std::ostringstream &out,
                 // put key && value
                 out << os.str() << ": ";
 
-                std::string xkey = os.str();
-                if (!xkey.empty() && *(xkey.end() - 1) == '"') {
-                    std::string::const_iterator end = xkey.end() - 1;
-                    std::string::const_iterator begin = xkey.begin();
-                    while (*begin++ != '"');
-                    xkey = std::string(begin, end);
+                std::string xkey;
+#if PY_MAJOR_VERSION == 2
+                if (PyString_Check(key)) {
+                    xkey = PyString_AsString(key);
                 }
+#else
+                if (PyUnicode_Check(key)) {
+                    xkey = PyUnicode_AsUTF8(key);
+                }
+#endif
                 if (PyMapping_HasKeyString(names,
                                            const_cast<char *>(xkey.c_str()))) {
                     out << "-hidden-";

--- a/python/test/dumptree.py
+++ b/python/test/dumptree.py
@@ -1,0 +1,44 @@
+from fastrpc import dumpTree
+import unittest
+
+class DumpTreeTest(unittest.TestCase):
+
+    def test_hide_sensitive_names(self):
+        value = {'extremely-long-key-name': 'sensitive-content'}
+        level = 3
+        names = {'extremely-long-key-name': 1}
+        pos = 0
+
+        self.assertEqual('{"extremely-...": -hidden-}', dumpTree(value, level, names, pos))
+
+    def test_hide_sensitive_pos(self):
+        value = ['one', 'two', 'three', 'four']
+        level = 3
+        names = {'extremely-long-key-name': 1}
+        pos = int('1010', 2)
+
+        self.assertEqual('("one", -hidden-, "three", -hidden-)', dumpTree(value, level, names, pos))
+
+
+    def test_dict_key_types(self):
+        level = 3
+        names = {}
+        pos = 0
+
+        self.assertEqual('{true: "first"}', dumpTree({True: 'first'}, level, names, pos))
+        self.assertEqual('{false: "second"}', dumpTree({False: 'second'}, level, names, pos))
+        self.assertEqual('{3: "third"}', dumpTree({3: 'third'}, level, names, pos))
+        self.assertEqual('{4.2: "fourth"}', dumpTree({4.2: 'fourth'}, level, names, pos))
+        self.assertEqual('{"5": "fifth"}', dumpTree({'5': 'fifth'}, level, names, pos))
+        test_hash_object = TestHashObject('sixth')
+        self.assertEqual('{'+str(test_hash_object)+': "sixth"}', dumpTree({test_hash_object: 'sixth'}, level, names, pos))
+
+class TestHashObject(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __hash__(self):
+        return hash((self.name))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed problem with print sensitive data.

Problem was in truncating key before check for sensitive data.