### PR TITLE
fix: fixed problem with dump sensitive data with treeDump #GDPR_RS-108

### DIFF
--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+python-fastrpc (8.0.4) stable; urgency=medium
+
+  * fix: fixed problem with dump sensitive data with treeDump #GDPR_RS-108
+
+ -- Martin Junk <martin.junk@firma.seznam.cz>  Thu, 29 Mar 2018 15:54:56 +0200
+
 python-fastrpc (8.0.3) stable; urgency=medium
 
   * Revert "fixed the README handing in setup.py after it was renamed"

--- a/python/fastrpcmodule.cc
+++ b/python/fastrpcmodule.cc
@@ -2690,14 +2690,11 @@ int printPyFastRPCTree(PyObject *tree, std::ostringstream &out,
 
                 // put key && value
                 out << os.str() << ": ";
-
-                std::string xkey = os.str();
-                if (!xkey.empty() && *(xkey.end() - 1) == '"') {
-                    std::string::const_iterator end = xkey.end() - 1;
-                    std::string::const_iterator begin = xkey.begin();
-                    while (*begin++ != '"');
-                    xkey = std::string(begin, end);
-                }
+#if PY_MAJOR_VERSION == 2
+                std::string xkey = PyString_AsString(key);
+#else
+                std::string xkey = PyUnicode_AsUTF8(key);
+#endif
                 if (PyMapping_HasKeyString(names,
                                            const_cast<char *>(xkey.c_str()))) {
                     out << "-hidden-";

--- a/python/test/dumptree.py
+++ b/python/test/dumptree.py
@@ -1,0 +1,23 @@
+from fastrpc import dumpTree
+import unittest
+
+class DumpTreeTest(unittest.TestCase):
+
+    def test_hide_sensitive_names(self):
+        value = {'extremely-long-key-name': 'sensitive-content'}
+        level = 3
+        names = {'extremely-long-key-name': 1}
+        pos = 0
+
+        self.assertEqual('{"extremely-...": -hidden-}', dumpTree(value, level, names, pos))
+
+    def test_hide_sensitive_pos(self):
+        value = ['one', 'two', 'three', 'four']
+        level = 3
+        names = {'extremely-long-key-name': 1}
+        pos = int('1010', 2)
+
+        self.assertEqual('("one", -hidden-, "three", -hidden-)', dumpTree(value, level, names, pos))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed problem with print sensitive data.

Problem was in truncating key before check for sensitive data.