### PR TITLE
fix: http client when using unix socket

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@
 #
 
 # initialize autoconf
-AC_INIT([fastrpc], [8.0.9], fastrpc@firma.seznam.cz)
+AC_INIT([fastrpc], [8.0.10], fastrpc@firma.seznam.cz)
 
 # initialize automake(use AC_INIT's arguments)
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfastrpc (8.0.10) UNRELEASED; urgency=medium
+
+  * fix: http client when using unix socket
+
+ -- Pavol Otto <pavol.otto@firma.seznam.cz>  Thu, 03 May 2018 09:38:53 +0200
+
 libfastrpc (8.0.9) stable; urgency=medium
 
   * added missing include

--- a/src/frpchttpclient.cc
+++ b/src/frpchttpclient.cc
@@ -91,7 +91,7 @@ inline void addHeader(StreamHolder_t& stream, const std::string& name, const T& 
 
 namespace FRPC {
 
-const std::string HTTPClient_t::HOST = "HOST";
+const std::string HTTPClient_t::HOST = "Host";
 const std::string HTTPClient_t::POST = "POST";
 const std::string HTTPClient_t::HTTP10 = "HTTP/1.0";
 const std::string HTTPClient_t::HTTP11 = "HTTP/1.1";
@@ -267,8 +267,15 @@ void HTTPClient_t::sendRequest(bool last) {
         StreamHolder_t os;
 
         //create header
-        os.os << POST << " " << url.path << ' ' << (useHTTP10 ? HTTP10 : HTTP11) << "\r\n";
-        os.os << HOST << ": " << url.host << ':' << url.port << "\r\n";
+        os.os << POST << ' ' << (url.isUnix() ? "/" : url.path) << ' '
+              << (useHTTP10 ? HTTP10 : HTTP11) << "\r\n";
+        if (!useHTTP10) {
+            os.os << HOST << ": ";
+            if (!url.isUnix()) {
+                os.os << url.host << ':' << url.port;
+            }
+            os.os << "\r\n";
+        }
 
         switch(useProtocol) {
         case XML_RPC:


### PR DESCRIPTION
When using unix socket, there were 2 problems with the old implementation:
- host header was set with the value `:0`, which is invalid
- the path to the unix socket was used as path in HTTP POST

Proposed fix included in this pull request
- set Host header to the empty value (a valid value and recommended situations without hostname)
- use `/` path in http request since it is the only reasonable as there's no way to specify the http path in the configuration (the `unix://` scheme doesn't have any way to specify it, it defines a path to the socket)