### PR TITLE
fix: on sending request release GIL

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfastrpc (8.1.0) UNRELEASED; urgency=medium
+
+  * Python: fix: on sending request release GIL
+
+ -- Martin Quarda <martin.quarda@firma.seznam.cz>  Thu, 03 Sep 2020 17:50:46 +0200
+
 libfastrpc (8.0.15) stable; urgency=medium
 
   * #74 Do not default to v1.0 in xmlrpc mode if no protocolVersion is specified in the server output.

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+python-fastrpc (8.1.0) UNRELEASED; urgency=medium
+
+  * fix: on sending request release GIL
+
+ -- Martin Quarda <martin.quarda@firma.seznam.cz>  Thu, 03 Sep 2020 18:17:20 +0200
+
 python-fastrpc (8.0.8) stable; urgency=medium
 
   * Fixed compilation of python module for python3

--- a/src/frpchttpclient.h
+++ b/src/frpchttpclient.h
@@ -136,6 +136,11 @@ public:
     virtual void flush();
 
     /**
+     * @brief tries to poll data before actual read, can be skipped
+     */
+    inline void waitOnReadyRead(){httpIO.waitOnReadyRead();};
+
+    /**
     * @brief write data to HTTP client
     * @param data pointer to data
     * @param size size of data

--- a/src/frpchttpio.cc
+++ b/src/frpchttpio.cc
@@ -310,6 +310,29 @@ std::string HTTPIO_t::readLineOpt(bool checkLimit, bool optional)
     }
 }
 
+void HTTPIO_t::waitOnReadyRead()
+{
+    pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    // èekání na data na socketu
+    int ready = TEMP_FAILURE_RETRY(
+            poll(&pfd, 1, readTimeout < 0 ? -1 : readTimeout));
+
+    switch (ready)
+    {
+    case 0:
+        throw ProtocolError_t(HTTP_TIMEOUT, "Timeout while reading.");
+
+    case -1:
+        // other error
+        STRERROR_PRE();
+        throw ProtocolError_t::format(HTTP_SYSCALL,
+                                        "Syscall error: <%d, %s>.",
+                                        ERRNO, STRERROR(ERRNO));
+    }
+}
+
 void HTTPIO_t::sendData(const char *data, size_t length, bool watchForResponse)
 {
     // zjistíme, kolik máme poslat

--- a/src/frpchttpio.h
+++ b/src/frpchttpio.h
@@ -68,7 +68,7 @@ public:
 
     /**
      * @short Return mame and value of item from http header.
-     * 
+     *
      * @param line item of header
      * @param name name if item
      * @param  value value of item
@@ -80,7 +80,7 @@ public:
     /**
      * @short Read line from socket.
      *
-     * @param checkLimit limit check  
+     * @param checkLimit limit check
      * @return read line
      */
     std::string readLine(bool checkLimit = false);
@@ -93,6 +93,11 @@ public:
      * @return read line
      */
     std::string readLineOpt(bool checkLimit = false, bool optional=false);
+
+    /**
+     * @short tries to poll data on socket without reading
+     */
+    void waitOnReadyRead();
 
     void readHeader(HTTPHeader_t &header);
     void readHeader(HTTPHeader_t &header, bool optional);
@@ -142,7 +147,7 @@ public:
     /** @short Send data to socket.
      *
      * @param data pointer to data
-     * @param length  data length 
+     * @param length  data length
      * @param watchForResponse says that sender receive too
      */
     void sendData(const char *data, size_t length,


### PR DESCRIPTION
Během požadavku se neuvolnoval GIL a tak knihovna prakticky nefunguje s threading modulem

Zvýšení minor verze kvůli tomu, že vyžaduje novou metodu u HTTPIO_t