### PR TITLE
do not report disconnected client if no request is in progress

### DIFF
--- a/src/frpchttp.h
+++ b/src/frpchttp.h
@@ -208,6 +208,8 @@ namespace FRPC {
                               // request
         HTTP_RESPONSE_NOT_READ, // attempt to send request without reading
                                 // response
+        HTTP_NO_REQUEST_RECEIVED, // attempted to read request, but connection was closed
+                                  // or timed out without receiving anything.
     };
     
 

--- a/src/frpchttpio.cc
+++ b/src/frpchttpio.cc
@@ -188,7 +188,11 @@ std::string HTTPIO_t::readLineOpt(bool checkLimit, bool optional)
         switch (ready)
         {
         case 0:
-            throw ProtocolError_t(HTTP_TIMEOUT, "Timeout while reading.");
+            if (optional) {
+                return "";
+            } else {
+                throw ProtocolError_t(HTTP_TIMEOUT, "Timeout while reading.");
+            }
 
         case -1:
             // other error

--- a/src/frpcserver.cc
+++ b/src/frpcserver.cc
@@ -134,6 +134,14 @@ void Server_t::serve(int fd,
             marshaller->flush();
             continue;
 
+        } catch(const ProtocolError_t &err) {
+            if (err.errorNum() == HTTP_NO_REQUEST_RECEIVED) {
+                // Failed to receive request. Connection was terminated (closed or timed out)
+                // before receiving anything -> finish silently.
+                break;
+            } else {
+                throw;
+            }
         } catch(const HTTPError_t &httpError) {
             sendHttpError(httpError);
             break;
@@ -208,10 +216,12 @@ void Server_t::readRequest(DataBuilder_t &builder,
         for (;;)
         {
             // read line from the socket, we check security limits for url
-            std::string line(io.readLine(true));
+            std::string line(io.readLineOpt(true, true));
 
-            if (line.empty())
-                continue;
+            if (line.empty()) {
+                throw ProtocolError_t(HTTP_NO_REQUEST_RECEIVED, "No request received");
+            }
+
             // break request line down
             std::vector<std::string> header(io.splitBySpace(line, 3));
             if (header.size() != 3)


### PR DESCRIPTION
This should silently ignore TCP probes which just open and close TCP connection. Nowadays this happens a lot with labrador, resulting in this spam in logs on error level:
```
FastRPC Protocol error while communicating with 10.249.70.19: <2, Connection closed by foreign host>.
```