### PR TITLE
misplaced catch of protocolerror in frpcserver

### DIFF
--- a/src/frpcserver.cc
+++ b/src/frpcserver.cc
@@ -134,6 +134,9 @@ void Server_t::serve(int fd,
             marshaller->flush();
             continue;
 
+        } catch(const HTTPError_t &httpError) {
+            sendHttpError(httpError);
+            break;
         } catch(const ProtocolError_t &err) {
             if (err.errorNum() == HTTP_NO_REQUEST_RECEIVED) {
                 // Failed to receive request. Connection was terminated (closed or timed out)
@@ -142,9 +145,6 @@ void Server_t::serve(int fd,
             } else {
                 throw;
             }
-        } catch(const HTTPError_t &httpError) {
-            sendHttpError(httpError);
-            break;
         }
 
         headerOut = HTTPHeader_t();


### PR DESCRIPTION
Catching the ProtocolError error before the HttpError error caused incorrect behavior for failed HTTP requests, such as not returning any data instead of the 405 status when using the wrong transfer method.