### PR TITLE
RFC: fixes python3.10 build of python module not working due to missing de…

### DIFF
--- a/python/fastrpcmodule.cc
+++ b/python/fastrpcmodule.cc
@@ -30,6 +30,8 @@
  */
 
 #define __ENABLE_WSTRING
+// defined here to indicate # args to PyArgs_ParseTuple use Py_ssize_t instead of int
+#define PY_SSIZE_T_CLEAN
 
 // Included first to get rid of the _POSIX_C_SOURCE warning
 #include <Python.h>
@@ -1682,7 +1684,7 @@ PyObject* ServerProxy_ServerProxy(ServerProxyObject *, PyObject *args,
 
     // parse arguments
     PyStrDataType_t serverUrl;
-    int serverUrlLen;
+    Py_ssize_t serverUrlLen;
     int readTimeout = -1;
     int writeTimeout = -1;
     int connectTimeout = -1;
@@ -1734,7 +1736,7 @@ PyObject* ServerProxy_ServerProxy(ServerProxyObject *, PyObject *args,
         // Initialization from ConfigParser and section
         PyObject *cfgParser;
         char *cfgSection;
-        int cfgSectionLen;
+        Py_ssize_t cfgSectionLen;
 
         if (!PyArg_ParseTuple(args, "Os#:ServerProxy.__init__",
                 &cfgParser, &cfgSection, &cfgSectionLen)) {


### PR DESCRIPTION
https://python.readthedocs.io/en/stable/c-api/arg.html#strings-and-buffers
https://bugs.python.org/issue36381

Recent changes to this made python3.10 build of the python module always fail with non-descriptive error (due to error masking in the argument parsing in ServerProxy constructor). 

I'd love to version-guard these changes but for the love of me can't find the version which introduced Py_ssize_t as the valid type to use in these situations. So making this a RFC...